### PR TITLE
lib: Make timestamp public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod epoch_units;
-mod timestamp;
+pub mod timestamp;
 pub mod units;
 
 #[cfg(test)]


### PR DESCRIPTION
This enables users of the library to meddle with the `epoch_converter::timestamp::Timestamp` struct which can be especially helpful when dealing with Rust's strict type system.